### PR TITLE
feat: 관리자 게시물 삭제 기능 구현

### DIFF
--- a/src/components/atom/Text/TextButton.tsx
+++ b/src/components/atom/Text/TextButton.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import Text, { TextProps } from '.';
 
 interface TextButtonProps extends TextProps {
@@ -16,7 +17,7 @@ const TextButton = ({
   ...props
 }: TextButtonProps) => {
   return (
-    <button onClick={onClick}>
+    <StyledButton onClick={onClick}>
       <Text
         size={size}
         block={block}
@@ -28,8 +29,12 @@ const TextButton = ({
       >
         {children}
       </Text>
-    </button>
+    </StyledButton>
   );
 };
 
 export default TextButton;
+
+const StyledButton = styled.button`
+  flex-shrink: 0;
+`;

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,4 +1,4 @@
-import { ErrorConfirm } from './../types/user';
+import { ErrorConfirm, UserRole, USER_ROLE } from './../types/user';
 import { useRecoilState, useResetRecoilState } from 'recoil';
 import { userState } from '~/recoil';
 import { UserApi } from '~/service';
@@ -19,12 +19,24 @@ export const useUser = () => {
   const isLoggedIn = currentUser.accessToken !== null;
   const { setToken, removeToken } = useToken();
 
+  const conFirmUserAuth = (authorities: UserRole[]) => {
+    return authorities.includes(USER_ROLE.ADMIN) ? USER_ROLE.ADMIN : USER_ROLE.USER;
+  };
+
   const login = async (data: LoginValues): Promise<ErrorConfirm> => {
     setCurrentUser({ ...currentUser });
 
     try {
       const response = await UserApi.login(data);
-      setCurrentUser({ ...response });
+      setCurrentUser({
+        accessToken: response.accessToken,
+        user: {
+          id: response.user.id,
+          nickname: response.user.nickname,
+          profileImage: response.user.profileImage,
+          role: conFirmUserAuth(response.user.authorities)
+        }
+      });
       setToken(response.accessToken);
 
       return {
@@ -62,7 +74,8 @@ export const useUser = () => {
         user: {
           id: response.id,
           nickname: response.nickname,
-          profileImage: response.profileImage
+          profileImage: response.profileImage,
+          role: conFirmUserAuth(response.authorities)
         }
       });
     } catch (e) {
@@ -72,7 +85,8 @@ export const useUser = () => {
         user: {
           id: null,
           nickname: null,
-          profileImage: null
+          profileImage: null,
+          role: null
         }
       });
     }

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -17,6 +17,7 @@ import { CourseApi } from '~/service';
 import theme from '~/styles/theme';
 import { ICourseDetail, ICourseForm } from '~/types/course';
 import { IPlaceForm } from '~/types/place';
+import { USER_ROLE } from '~/types/user';
 import { sliceDate } from '~/utils/converter';
 
 export const getServerSideProps = async (context: NextPageContext) => {
@@ -108,6 +109,7 @@ const CourseDetail = ({ course, courseId }: Props) => {
   useEffect(() => {
     if (isLoggedIn) {
       getDetailInfo();
+      console.log(currentUser, 'currentUser');
     }
   }, [courseId, isLoggedIn]);
 
@@ -125,8 +127,9 @@ const CourseDetail = ({ course, courseId }: Props) => {
               <Title level={2} size="lg" fontWeight={700} block>
                 {detailData.title}
               </Title>
-              {currentUser.user.id === detailData.userId && (
-                <HeaderButtons>
+
+              <HeaderButtons>
+                {currentUser.user.id === detailData.userId && (
                   <Link
                     href={{
                       pathname: `/course/${courseId}/edit`,
@@ -136,11 +139,14 @@ const CourseDetail = ({ course, courseId }: Props) => {
                   >
                     수정
                   </Link>
-                  <Text.Button color="gray" onClick={() => setModalVisible(true)}>
-                    삭제
-                  </Text.Button>
-                </HeaderButtons>
-              )}
+                )}
+                {currentUser.user.id === detailData.userId ||
+                  (currentUser.user.role === USER_ROLE.ADMIN && (
+                    <Text.Button color="gray" onClick={() => setModalVisible(true)}>
+                      삭제
+                    </Text.Button>
+                  ))}
+              </HeaderButtons>
             </CourseTitle>
             <CourseDate>
               <Text color="gray">업로드한 날: {sliceDate(detailData.createdAt)}</Text>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
 import React, { FormEvent, ReactElement, useEffect, useRef, useState } from 'react';
 import { Button, Link, PageContainer, Image, Icon } from '~/components/atom';
-import { CourseList, PlaceList } from '~/components/common';
+import { CourseList, PlaceList, Toast } from '~/components/common';
 import Layout from '~/components/common/Layout';
 import ArrowTitle from '~/components/common/ArrowTitle';
 import { CourseApi, PlaceApi } from '~/service';
@@ -73,6 +73,10 @@ const HomePage = ({ places, courses }: Props) => {
   };
 
   useEffect(() => {
+    if (!courses || !places) {
+      Toast.show('데이터 요청에 실패하였습니다.');
+    }
+
     if (isLoggedIn) {
       getCategoryData();
     }

--- a/src/recoil/index.ts
+++ b/src/recoil/index.ts
@@ -1,6 +1,5 @@
 import { atom } from 'recoil';
 import { UserState } from '~/types/user';
-// 여기서 localstorage 불러와서 사용 안됨
 
 export const userState = atom<UserState>({
   key: 'userState',
@@ -9,7 +8,8 @@ export const userState = atom<UserState>({
     user: {
       id: null,
       nickname: null,
-      profileImage: null
+      profileImage: null,
+      role: null
     }
   }
 });

--- a/src/service/core/workers.ts
+++ b/src/service/core/workers.ts
@@ -4,6 +4,7 @@ import TokenStorage from '~/utils/storage/TokenStorage';
 const createInstance = (url: string, config?: AxiosRequestConfig): AxiosInstance => {
   return axios.create({
     baseURL: url,
+    timeout: 10000,
     headers: {
       'Content-Type': 'application/json'
     },
@@ -32,6 +33,12 @@ const handleError = (error: AxiosError) => {
     window.alert('현재 서버에 문제가 있습니다.');
     console.error(error);
   }
+
+  if (error.code === 'ECONNABORTED' || error.response?.status === 408) {
+    alert('요청이 만료되었습니다.');
+    console.error(error);
+  }
+
   return Promise.reject(error);
 };
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -2,8 +2,15 @@ export interface User {
   id: number | null;
   nickname: string | null;
   profileImage: string | null;
+  role: UserRole | null;
 }
 
+export const USER_ROLE = {
+  ADMIN: 'ROLE_ADMIN',
+  USER: 'ROLE_USER'
+} as const;
+
+export type UserRole = typeof USER_ROLE[keyof typeof USER_ROLE];
 export interface UserState {
   accessToken: string | null;
   user: User;


### PR DESCRIPTION
# ✅ 이슈번호
closes #262 

# 📌 구현 내역
## 관리자 게시물 삭제 기능 구현
- API가 변경되어 userState에 role 정보를 추가했습니다.
- 관리자로 등록된 아이디, 게시물 작성자에게 삭제 버튼이 보입니다.
- API 테스트를 하면서 API요청 전체가 먹통이 되는 일이 있었는데 SSR로 작업된 페이지의 경우 서버 요청의 응답이 늦으면 배포사이트(Vercel)에서 페이지 자체 접근이 안되어 Axios에 timeout을 설정해두었습니다.
- 그리고 SSR로 되어있는 메인페이지의 경우 서버 요청 실패시 client 에서 구현한 에러 메세지 처리가 되지 않기 때문에
따로 내부에 구현해두었습니다.